### PR TITLE
Add error message for invalid loginless links.

### DIFF
--- a/pairings/accounts/viewsets.py
+++ b/pairings/accounts/viewsets.py
@@ -7,6 +7,7 @@ from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from rest_framework import decorators, mixins, response, status, throttling, viewsets
+from django.contrib import messages
 
 
 class UserViewSet(
@@ -55,4 +56,6 @@ class UserViewSet(
         user = validate_token(token)
         if user is not None:
             login(request, user, backend=settings.AUTHENTICATION_BACKENDS[0])
+        else:
+            messages.error(request, "Login link is invalid or has expired. Please request a new one.")
         return redirect("index")

--- a/pairings/frontend/templates/frontend/base.html
+++ b/pairings/frontend/templates/frontend/base.html
@@ -25,6 +25,18 @@
   </head>
 
   <body>
+    <div class="container-lg mt-3">
+        {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-danger border border-danger shadow-sm alert-dismissible fade show" role="alert">
+                <i class="feather" data-feather="alert-circle"></i>
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            {% endfor %}
+        {% endif %}
+    </div>
+
     <div
       class="alert alert-success alert-dismissible fade hide"
       id="alert-unread-news"

--- a/pairings/frontend/templates/frontend/base.html
+++ b/pairings/frontend/templates/frontend/base.html
@@ -26,15 +26,17 @@
 
   <body>
     <div class="container-lg mt-3">
-        {% if messages %}
-            {% for message in messages %}
-            <div class="alert alert-danger border border-danger shadow-sm alert-dismissible fade show" role="alert">
-                <i class="feather" data-feather="alert-circle"></i>
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-            {% endfor %}
-        {% endif %}
+        {% for message in messages %}
+        <div class="alert 
+            alert-{% if message.level_tag == 'error' %}danger
+                  {% elif message.level_tag == 'debug' %}secondary
+                  {% else %}{{ message.level_tag }}{% endif %} 
+            border shadow-sm alert-dismissible fade show" 
+            role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        {% endfor %}
     </div>
 
     <div


### PR DESCRIPTION
Added proper error handling for invalid loginless authentication links.

Changes made:
- Added error handling in loginless function with Django messages framework
- Added conditional message display block in base template

What exactly triggers an error message:
- validate_token() returns None instead of a user object
- validation logic unchanged, including identical output for either invalid or expired token
